### PR TITLE
[codex] Release v1.5.2 weather fixes

### DIFF
--- a/APRSPropView.manifest
+++ b/APRSPropView.manifest
@@ -3,7 +3,7 @@
   <assemblyIdentity
     type="win32"
     name="WickerMade.APRSPropView"
-    version="1.5.1.0"
+    version="1.5.2.0"
     processorArchitecture="amd64"
   />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # APRS PropView — VHF Propagation Monitor
 
-**Version 1.5.1** | May 24, 2026
+**Version 1.5.2** | May 25, 2026
 
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 
@@ -9,7 +9,7 @@
 
 A real-time APRS digipeater and IGate application focused on visualizing VHF propagation conditions. Features an interactive web dashboard, advanced analytics, band opening alerts, and full APRS-IS policy compliance. Runs from source or as a single portable `.exe`.
 
-Version 1.5.1 adds multiple named RF ports, WXnow.txt weather transmit, compact Status/DX beacons, and per-port origin display for packets and stations.
+Version 1.5.2 fixes APRS weather packet detection/transmit formatting, respects configured digipeater aliases, adds WXnow.txt current conditions, and shows transmitted packets in the packet list.
 
 Linux and Raspberry Pi installs are covered in [docs/linux-raspberry-pi.md](docs/linux-raspberry-pi.md).
 

--- a/build_exe.py
+++ b/build_exe.py
@@ -96,7 +96,7 @@ def _write_manifest(path):
   <assemblyIdentity
     type="win32"
     name="WickerMade.APRSPropView"
-    version="1.5.1.0"
+    version="1.5.2.0"
     processorArchitecture="amd64"
   />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
@@ -158,11 +158,11 @@ VSVersionInfo(
           [
             StringStruct(u'CompanyName', u'Wicker Made, LLC'),
             StringStruct(u'FileDescription', u'APRS PropView - VHF Propagation Monitor'),
-            StringStruct(u'FileVersion', u'1.5.1.0'),
+            StringStruct(u'FileVersion', u'1.5.2.0'),
             StringStruct(u'InternalName', u'APRSPropView'),
             StringStruct(u'OriginalFilename', u'APRSPropView.exe'),
             StringStruct(u'ProductName', u'APRS PropView'),
-            StringStruct(u'ProductVersion', u'1.5.1.0'),
+            StringStruct(u'ProductVersion', u'1.5.2.0'),
           ]
         )
       ]

--- a/config.toml.example
+++ b/config.toml.example
@@ -156,6 +156,7 @@ max_length = 67
 [weather]
 enabled = false
 location_code = ""
+# Current sources: open_meteo, wxnow
 current_provider = "open_meteo"
 alert_provider = "auto"
 weatherbit_api_key = ""

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@
 Launch this to start the application. The web interface opens automatically.
 """
 
-APP_VERSION = "1.5.1"
+APP_VERSION = "1.5.2"
 
 import asyncio
 import sys

--- a/server/app.py
+++ b/server/app.py
@@ -1707,7 +1707,7 @@ def create_app(
                 config.weather.enabled = bool(wc.get("enabled", config.weather.enabled))
                 config.weather.location_code = (wc.get("location_code", config.weather.location_code) or "").strip()
                 current_provider = (wc.get("current_provider", config.weather.current_provider) or "open_meteo").strip().lower()
-                config.weather.current_provider = current_provider if current_provider in {"open_meteo"} else "open_meteo"
+                config.weather.current_provider = current_provider if current_provider in {"open_meteo", "wxnow"} else "open_meteo"
                 alert_provider = (wc.get("alert_provider", config.weather.alert_provider) or "auto").strip().lower()
                 if alert_provider in {"nws", "open_meteo_risk"}:
                     alert_provider = "auto"

--- a/server/aprs_parser.py
+++ b/server/aprs_parser.py
@@ -132,10 +132,10 @@ def parse_packet(raw: str, source: str = "rf") -> APRSPacket:
 
         if dti in ("!", "="):
             _parse_position(pkt, info[1:], with_messaging=(dti == "="))
-            pkt.packet_type = "position" if pkt.has_position else "other"
+            pkt.packet_type = _position_packet_type(pkt)
         elif dti in ("/", "@"):
             _parse_position_with_timestamp(pkt, info[1:], with_messaging=(dti == "@"))
-            pkt.packet_type = "position" if pkt.has_position else "other"
+            pkt.packet_type = _position_packet_type(pkt)
         elif dti == ":":
             _parse_message(pkt, info[1:])
             pkt.packet_type = "message"
@@ -196,6 +196,12 @@ def _parse_lat_lon(data: str):
         return lat, lon, rest, sym_table, sym_code
     except (ValueError, IndexError):
         return None
+
+
+def _position_packet_type(pkt: APRSPacket) -> str:
+    if not pkt.has_position:
+        return "other"
+    return "weather" if pkt.symbol_code == "_" else "position"
 
 
 def _is_uncompressed_position(data: str) -> bool:

--- a/server/digipeater.py
+++ b/server/digipeater.py
@@ -91,8 +91,8 @@ class Digipeater:
             if digi_call == self.my_call.upper():
                 return self._mark_digipeated(frame, i)
 
-            # WIDEn-N handling
-            if self._is_wide_alias(digi_call):
+            # WIDEn-N handling, restricted to the aliases the operator enabled.
+            if self._is_wide_alias(digi_call) and digi_call in self.aliases:
                 return self._handle_wide(frame, i, digi)
 
             # Check against configured aliases

--- a/server/packet_handler.py
+++ b/server/packet_handler.py
@@ -487,13 +487,15 @@ class PacketHandler:
             frame.destination = AX25Address.from_string("APPRPV")
             frame.digipeaters = [AX25Address.from_string("WIDE1-1")]
             frame.info = info.encode("latin-1")
-            await self._transmit_rf(frame)
+            if await self._transmit_rf(frame):
+                await self._record_tx_packet(frame.to_aprs_string(), "RF TX")
 
         # Send on APRS-IS
         if send_is and self.aprs_is and self.aprs_is.connected:
             is_packet = f"{my_call}>APPRPV,TCPIP*:{info}"
-            await self.aprs_is.send(is_packet)
-            self.stats["is_tx"] += 1
+            if await self.aprs_is.send(is_packet):
+                self.stats["is_tx"] += 1
+                await self._record_tx_packet(is_packet, "APRS-IS TX")
 
     def get_messages(self, limit: int = 100) -> List[Dict[str, Any]]:
         """Return recent messages (newest first)."""
@@ -514,6 +516,7 @@ class PacketHandler:
     async def _transmit_rf(self, frame: AX25Frame):
         """Transmit an AX.25 frame on all RF interfaces."""
         encoded = frame.encode()
+        sent = 0
         for iface in self.rf_interfaces:
             if not getattr(iface, "can_transmit", True):
                 logger.debug(f"Skipping RF TX on receive-only interface {iface.name}")
@@ -521,9 +524,42 @@ class PacketHandler:
             try:
                 await iface.send(encoded)
                 self.stats["rf_tx"] += 1
+                sent += 1
                 logger.debug(f"RF TX via {iface.name}: {frame.to_aprs_string()}")
             except Exception as e:
                 logger.error(f"RF TX error on {iface.name}: {e}")
+        return sent
+
+    async def _record_tx_packet(self, raw: str, transport: str):
+        packet = parse_packet(raw, source="tx")
+        packet.port_name = transport
+        await self.tracker.db.log_packet(
+            source="tx",
+            from_call=packet.from_call,
+            to_call=packet.to_call,
+            path=packet.path,
+            raw=packet.raw,
+            packet_type=packet.packet_type,
+            latitude=packet.latitude,
+            longitude=packet.longitude,
+            port_name=transport,
+        )
+        await self.ws.broadcast({
+            "type": "packet",
+            "data": {
+                "timestamp": time.time(),
+                "source": "tx",
+                "from_call": packet.from_call,
+                "to_call": packet.to_call,
+                "path": packet.path,
+                "raw": packet.raw,
+                "packet_type": packet.packet_type,
+                "latitude": packet.latitude,
+                "longitude": packet.longitude,
+                "port_name": transport,
+                "distance_km": None,
+            },
+        })
 
     async def transmit_aprs_info(
         self,
@@ -564,13 +600,16 @@ class PacketHandler:
                 if hop.strip()
             ]
             frame.info = info.encode("latin-1")
-            await self._transmit_rf(frame)
+            if await self._transmit_rf(frame):
+                await self._record_tx_packet(frame.to_aprs_string(), "RF TX")
 
         is_sent = False
         if send_is and aprs_is_available:
-            is_sent = await self.aprs_is.send(f"{source_call}>{destination},TCPIP*:{info}")
+            is_packet = f"{source_call}>{destination},TCPIP*:{info}"
+            is_sent = await self.aprs_is.send(is_packet)
             if is_sent:
                 self.stats["is_tx"] += 1
+                await self._record_tx_packet(is_packet, "APRS-IS TX")
 
         await self._broadcast_stats()
 
@@ -736,12 +775,28 @@ class PacketHandler:
                 frame.digipeaters = []
 
             frame.info = info.encode("latin-1")
-            await self._transmit_rf(frame)
+            if await self._transmit_rf(frame):
+                await self._record_tx_packet(frame.to_aprs_string(), "RF TX")
             logger.info(f"Beacon RF TX: {cfg.full_callsign}>APPRPV via {path_str or 'DIRECT'}")
 
         # Beacon on APRS-IS
         if mode in {"aprs_is", "both"} and self.aprs_is and self.aprs_is.connected:
-            await self.aprs_is.send_position()
+            if await self.aprs_is.send_position():
+                from server.aprs_parser import make_position_packet, build_station_beacon_comment
+
+                is_info = make_position_packet(
+                    cfg.full_callsign,
+                    cfg.latitude,
+                    cfg.longitude,
+                    cfg.symbol_table,
+                    cfg.symbol_code,
+                    build_station_beacon_comment(
+                        comment=cfg.comment,
+                        phg=cfg.phg,
+                        equipment=cfg.equipment,
+                    ),
+                )
+                await self._record_tx_packet(f"{cfg.full_callsign}>APPRPV,TCPIP*:{is_info}", "APRS-IS TX")
             logger.info("Beacon APRS-IS TX")
 
         if mode == "rf" and not self.rf_interfaces:

--- a/server/station_tracker.py
+++ b/server/station_tracker.py
@@ -59,6 +59,52 @@ class StationTracker:
         self.my_lat = float(latitude)
         self.my_lon = float(longitude)
 
+    def _propview_transmit_callsigns(self) -> set[str]:
+        base = (self.config.station.callsign or "").strip().upper()
+        calls = {self.config.station.full_callsign.upper()}
+        if base:
+            wx_ssid = max(0, min(15, int(getattr(self.config.wxnow, "ssid", 13) or 0)))
+            calls.add(f"{base}-{wx_ssid}" if wx_ssid else base)
+        return {call for call in calls if call}
+
+    async def _log_packet_only(
+        self,
+        packet: APRSPacket,
+        port_name: str,
+        distance_km: Optional[float] = None,
+        commit: bool = True,
+    ):
+        await self.db.log_packet(
+            source=packet.source,
+            from_call=packet.from_call,
+            to_call=packet.to_call,
+            path=packet.path,
+            raw=packet.raw,
+            packet_type=packet.packet_type,
+            latitude=packet.latitude,
+            longitude=packet.longitude,
+            port_name=port_name,
+            commit=commit,
+        )
+        await self.ws.broadcast(
+            {
+                "type": "packet",
+                "data": {
+                    "timestamp": time.time(),
+                    "source": packet.source,
+                    "from_call": packet.from_call,
+                    "to_call": packet.to_call,
+                    "path": packet.path,
+                    "raw": packet.raw,
+                    "packet_type": packet.packet_type,
+                    "latitude": packet.latitude,
+                    "longitude": packet.longitude,
+                    "port_name": port_name,
+                    "distance_km": distance_km,
+                },
+            }
+        )
+
     async def track_packet(self, packet: APRSPacket):
         """Process a parsed packet and update station tracking."""
         source = packet.source  # 'rf' or 'aprs_is'
@@ -115,38 +161,10 @@ class StationTracker:
                 source="self_packet",
             )
 
-        is_own_packet = callsign.upper() == self.config.station.full_callsign.upper()
-        if is_own_packet and packet.packet_type == "message" and not packet.has_position:
-            await self.db.log_packet(
-                source=source,
-                from_call=callsign,
-                to_call=packet.to_call,
-                path=packet.path,
-                raw=packet.raw,
-                packet_type=packet.packet_type,
-                latitude=packet.latitude,
-                longitude=packet.longitude,
-                port_name=port_name,
-            )
-            await self.ws.broadcast(
-                {
-                    "type": "packet",
-                    "data": {
-                        "timestamp": time.time(),
-                        "source": source,
-                        "from_call": callsign,
-                        "to_call": packet.to_call,
-                        "path": packet.path,
-                        "raw": packet.raw,
-                        "packet_type": packet.packet_type,
-                        "latitude": packet.latitude,
-                        "longitude": packet.longitude,
-                        "port_name": port_name,
-                        "distance_km": None,
-                    },
-                }
-            )
-            logger.debug("Ignoring own message packet for station tracking: %s", callsign)
+        is_own_packet = callsign.upper() in self._propview_transmit_callsigns()
+        if is_own_packet:
+            await self._log_packet_only(packet, port_name)
+            logger.debug("Ignoring own PropView packet for station tracking: %s", callsign)
             return
 
         # Calculate distance if we have both positions
@@ -391,7 +409,11 @@ class StationTracker:
         prop_cfg = self.config.propagation
 
         # Get RF stations with distances for the last hour
-        rf_1h = await self.db.get_stations(source="rf", since=now - 3600)
+        own_calls = self._propview_transmit_callsigns()
+        rf_1h = [
+            station for station in await self.db.get_stations(source="rf", since=now - 3600)
+            if (station.get("callsign") or "").upper() not in own_calls
+        ]
 
         # Split RF stations into direct-heard local and relayed regional groups
         all_distances = [s["distance_km"] for s in rf_1h if s.get("distance_km")]
@@ -406,8 +428,14 @@ class StationTracker:
         regional_stations = [s for s in rf_1h if not self._is_direct_path(s.get("last_path", ""))]
         regional_distances = [s["distance_km"] for s in regional_stations if s.get("distance_km")]
 
-        rf_6h = await self.db.get_stations(source="rf", since=now - 21600)
-        rf_24h = await self.db.get_stations(source="rf", since=now - 86400)
+        rf_6h = [
+            station for station in await self.db.get_stations(source="rf", since=now - 21600)
+            if (station.get("callsign") or "").upper() not in own_calls
+        ]
+        rf_24h = [
+            station for station in await self.db.get_stations(source="rf", since=now - 86400)
+            if (station.get("callsign") or "").upper() not in own_calls
+        ]
         regional_count_6h = sum(1 for s in rf_6h if not self._is_direct_path(s.get("last_path", "")))
         regional_count_24h = sum(1 for s in rf_24h if not self._is_direct_path(s.get("last_path", "")))
 

--- a/server/weather.py
+++ b/server/weather.py
@@ -16,6 +16,7 @@ import time
 import urllib.request
 import urllib.error
 import urllib.parse
+from pathlib import Path
 from typing import Optional, Dict, Any, List, Tuple
 
 from server.config import Config
@@ -720,6 +721,8 @@ class WeatherManager:
 
     @property
     def is_configured(self) -> bool:
+        if (self.config.weather.current_provider or "").strip().lower() == "wxnow":
+            return bool(self.config.weather.enabled and self.config.wxnow.file_path)
         return bool(
             self.config.weather.enabled
             and self.config.weather.location_code
@@ -797,6 +800,9 @@ class WeatherManager:
 
     async def get_current_weather(self, force: bool = False) -> Optional[Dict[str, Any]]:
         """Get current weather, fetching from API if cache is stale."""
+        if (self.config.weather.current_provider or "").strip().lower() == "wxnow":
+            return self._get_wxnow_current_weather()
+
         if not self.is_configured:
             return None
 
@@ -825,6 +831,27 @@ class WeatherManager:
             self._last_fetch = time.time()
 
         return self._current
+
+    def _get_wxnow_current_weather(self) -> Optional[Dict[str, Any]]:
+        path_value = (getattr(self.config.wxnow, "file_path", "") or "").strip()
+        if not path_value:
+            return None
+        path = Path(path_value).expanduser()
+        if not path.exists() or not path.is_file():
+            return None
+
+        from server.wxnow import parse_weather_body_values, parse_wxnow_text
+
+        reading = parse_wxnow_text(path.read_text(encoding="ascii", errors="strict"), path.stat().st_mtime)
+        weather = parse_weather_body_values(reading)
+        weather["location_name"] = "WXnow.txt"
+        weather["location_code"] = "WXnow.txt"
+        weather["wind_direction_label"] = _wind_direction_label(
+            weather.get("wind_direction", 0) or 0
+        )
+        self._current = weather
+        self._last_fetch = time.time()
+        return weather
 
     async def get_alerts(self, force: bool = False) -> List[Dict[str, Any]]:
         """Get configured weather alerts, fetching from API if cache is stale."""

--- a/server/wxnow.py
+++ b/server/wxnow.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from server.config import Config
 
@@ -87,8 +87,61 @@ def build_wxnow_info(config: Config, reading: WxNowReading) -> str:
         code = (wx.symbol_code or "_")[:1]
         return f"@{timestamp}{lat}{table}{lon}{code}{reading.weather_body}"
 
-    timestamp = reading.timestamp.strftime("%m%d%H%M")
-    return f"_{timestamp}{reading.weather_body}"
+    return f"_{reading.weather_body}"
+
+
+def parse_weather_body_values(reading: WxNowReading) -> dict[str, Any]:
+    """Parse common APRS WX body fields into dashboard current conditions."""
+    body = reading.weather_body
+    values: dict[str, Any] = {
+        "time": reading.timestamp.isoformat(),
+        "raw": body,
+        "source": "wxnow",
+    }
+
+    wind = re.match(r"^(?P<dir>[0-9. ]{3})/(?P<speed>[0-9. ]{3})", body)
+    if wind:
+        try:
+            values["wind_direction"] = int(wind.group("dir").strip().replace(".", "") or 0)
+        except ValueError:
+            pass
+        try:
+            values["wind_speed_mph"] = int(wind.group("speed").strip().replace(".", "") or 0)
+        except ValueError:
+            pass
+
+    def field(pattern: str) -> Optional[int]:
+        match = re.search(pattern, body)
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
+
+    temperature = field(r"t(-?\d{3})")
+    if temperature is not None:
+        values["temperature"] = temperature
+        values["feels_like"] = temperature
+
+    gust = field(r"g(\d{3})")
+    if gust is not None:
+        values["wind_gusts_mph"] = gust
+
+    humidity = field(r"h(\d{2})")
+    if humidity is not None:
+        values["humidity"] = 100 if humidity == 0 else humidity
+
+    pressure = field(r"b(\d{5})")
+    if pressure is not None:
+        values["pressure"] = pressure / 10.0
+
+    rain_hour = field(r"r(\d{3})")
+    if rain_hour is not None:
+        values["precipitation_in"] = rain_hour / 100.0
+        values["rain"] = rain_hour / 100.0
+
+    return values
 
 
 class WxNowTransmitter:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1018,6 +1018,7 @@ html.ui-theme-light #tab-messages.active {
 
 .packet-item .pkt-source.rf { color: var(--rf-color); }
 .packet-item .pkt-source.aprs_is { color: var(--is-color); }
+.packet-item .pkt-source.tx { color: var(--accent-color); }
 .packet-item .pkt-source.rf {
     max-width: 150px;
     display: inline-block;

--- a/static/index.html
+++ b/static/index.html
@@ -238,6 +238,7 @@
                             <option value="">All</option>
                             <option value="rf">RF Only</option>
                             <option value="aprs_is">APRS-IS Only</option>
+                            <option value="tx">Transmitted Only</option>
                         </select>
                     </label>
                     <button id="btn-clear-packets" class="btn-small">Clear</button>
@@ -1086,6 +1087,7 @@
                                 <label for="cfg-wx-current-provider">Current Conditions</label>
                                 <select id="cfg-wx-current-provider">
                                     <option value="open_meteo">Open-Meteo - global, no key</option>
+                                    <option value="wxnow">WXnow.txt - transmitted values</option>
                                 </select>
                             </div>
                             <div class="settings-row">
@@ -1376,7 +1378,7 @@
                 <div class="about-panel">
                     <div class="about-header">
                         <h2>APRS PropView</h2>
-                        <span id="about-version" class="about-version">v1.5.1</span>
+                        <span id="about-version" class="about-version">v1.5.2</span>
                     </div>
                     <div class="about-section">
                         <p>A real-time APRS digipeater and IGate focused on VHF propagation, live mapping, APRS messaging, analytics, and weather-aware situational awareness.</p>
@@ -1392,7 +1394,7 @@
                     </div>
                     <div class="about-section">
                         <h3>Build Info</h3>
-                        <p>Version: <span id="about-version-detail">1.5.1</span></p>
+                        <p>Version: <span id="about-version-detail">1.5.2</span></p>
                         <p>Release Date: <span id="about-date">May 24, 2026</span></p>
                         <p>Highlights: multiple named RF ports, WXnow.txt weather transmit, compact Status/DX beacons, and per-port packet/station origin display.</p>
                     </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1439,7 +1439,7 @@
 
     function renderUpdateStatus(data, els) {
         const { messageEl, detailEl, linkEl, footerEl } = els;
-        const currentVersion = data?.current_version || '1.5.1';
+        const currentVersion = data?.current_version || '1.5.2';
         const latestVersion = data?.latest_version || currentVersion;
         const releaseUrl = data?.release_url || 'https://github.com/RF-YVY/APRS-PropView/releases';
         const publishedAt = data?.published_at ? formatReleaseDate(data.published_at) : '';

--- a/static/js/stations.js
+++ b/static/js/stations.js
@@ -206,7 +206,9 @@ class StationManager {
         const time = pkt.timestamp
             ? new Date(pkt.timestamp * 1000).toLocaleTimeString()
             : '';
-        const sourceLabel = pkt.source === 'rf' ? (pkt.port_name || 'RF') : 'IS';
+        const sourceLabel = pkt.source === 'rf'
+            ? (pkt.port_name || 'RF')
+            : (pkt.source === 'tx' ? (pkt.port_name || 'TX') : 'IS');
         const sourceClass = pkt.source || 'rf';
 
         const el = document.createElement('div');

--- a/tests/test_aprs_compliance.py
+++ b/tests/test_aprs_compliance.py
@@ -8,14 +8,16 @@ from server.aprs_parser import make_message_packet, parse_packet
 from server.app import _is_valid_message_addressee, _is_valid_station_callsign, _validate_config
 from server.analytics import AnalyticsEngine
 from server.alerts import AlertConfig, AlertManager
+from server.ax25 import AX25Address, AX25Frame
 from server.config import Config, RFPortConfig
 from server.database import Database
+from server.digipeater import Digipeater
 from server.packet_handler import PacketHandler
 from server.station_tracker import StationTracker
 from server.websocket_manager import WebSocketManager
 from server.gps import GPSManager, parse_nmea_position
 from server.status_report import build_dx_status_text, trim_status_text
-from server.wxnow import build_wxnow_info, parse_wxnow_text
+from server.wxnow import build_wxnow_info, parse_weather_body_values, parse_wxnow_text
 
 
 class APRSParserComplianceTests(unittest.TestCase):
@@ -38,6 +40,16 @@ class APRSParserComplianceTests(unittest.TestCase):
         self.assertEqual(packet.addressee, "N0CALL")
         self.assertEqual(packet.message_text, "Hi")
         self.assertEqual(packet.message_id, "001")
+
+    def test_position_weather_symbol_is_weather_packet(self):
+        packet = parse_packet(
+            "K5ABC-13>APPRPV:@071400z3530.00N/09745.00W_292/004g011t098h36b10139",
+            source="rf",
+        )
+
+        self.assertEqual(packet.packet_type, "weather")
+        self.assertAlmostEqual(packet.latitude, 35.5)
+        self.assertEqual(packet.symbol_code, "_")
 
     def test_compressed_position_keeps_full_comment(self):
         packet = parse_packet("CALL>APRS:!/5L!!<*e7Pxyzcomment", source="rf")
@@ -94,9 +106,9 @@ class APRSISComplianceTests(unittest.TestCase):
         config = Config()
         config.station.callsign = "K5ABC"
         config.aprs_is.passcode = "12345"
-        client = APRSISClient(config, lambda packet: None, app_version="1.5.1")
+        client = APRSISClient(config, lambda packet: None, app_version="1.5.2")
 
-        self.assertIn("vers APRSPropView 1.5.1", client._build_login())
+        self.assertIn("vers APRSPropView 1.5.2", client._build_login())
 
 
 class ConfigTests(unittest.TestCase):
@@ -174,8 +186,40 @@ class WxNowTests(unittest.TestCase):
 
         self.assertEqual(
             build_wxnow_info(config, reading),
-            "_07071400292/004g011t098h36b10139jDvs9",
+            "_292/004g011t098h36b10139jDvs9",
         )
+
+    def test_parse_wxnow_values_for_current_conditions(self):
+        reading = parse_wxnow_text("Feb 09 2021 13:00\n086/004g008t028r000p000P000h75b10007\n")
+        values = parse_weather_body_values(reading)
+
+        self.assertEqual(values["wind_direction"], 86)
+        self.assertEqual(values["wind_speed_mph"], 4)
+        self.assertEqual(values["wind_gusts_mph"], 8)
+        self.assertEqual(values["temperature"], 28)
+        self.assertEqual(values["humidity"], 75)
+        self.assertEqual(values["pressure"], 1000.7)
+
+
+class DigipeaterTests(unittest.TestCase):
+    def _frame(self, path):
+        return AX25Frame(
+            destination=AX25Address.from_string("APRS"),
+            source=AX25Address.from_string("K1ABC"),
+            digipeaters=[AX25Address.from_string(hop) for hop in path],
+            info=b"!3530.00N/09745.00W-Test",
+        )
+
+    def test_only_configured_wide_aliases_are_digipeated(self):
+        config = Config()
+        config.station.callsign = "K5ABC"
+        config.station.ssid = 1
+        config.digipeater.aliases = ["WIDE1-1"]
+        digi = Digipeater(config)
+
+        self.assertIsNone(digi.should_digipeat(self._frame(["WIDE2-1"])))
+        digi = Digipeater(config)
+        self.assertIsNotNone(digi.should_digipeat(self._frame(["WIDE1-1"])))
 
 
 class StatusDxTests(unittest.TestCase):

--- a/version_info.txt
+++ b/version_info.txt
@@ -18,11 +18,11 @@ VSVersionInfo(
           [
             StringStruct(u'CompanyName', u'Wicker Made, LLC'),
             StringStruct(u'FileDescription', u'APRS PropView - VHF Propagation Monitor'),
-            StringStruct(u'FileVersion', u'1.5.1.0'),
+            StringStruct(u'FileVersion', u'1.5.2.0'),
             StringStruct(u'InternalName', u'APRSPropView'),
             StringStruct(u'OriginalFilename', u'APRSPropView.exe'),
             StringStruct(u'ProductName', u'APRS PropView'),
-            StringStruct(u'ProductVersion', u'1.5.1.0'),
+            StringStruct(u'ProductVersion', u'1.5.2.0'),
           ]
         )
       ]


### PR DESCRIPTION
## Summary
- Bump APRS PropView to v1.5.2 across runtime, About UI, README, manifest, and Windows version metadata.
- Fix WXnow/APRS weather packet handling so positionless packets use the expected `_CSE/SPD...` body and positioned weather packets classify as weather.
- Add WXnow.txt as a current-conditions source and include transmitted packets in the packet list with a TX filter.
- Restrict digipeating to configured WIDEn-N aliases and keep PropView transmit SSIDs out of propagation reports.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q` -> 44 passed
- `python build_exe.py` -> rebuilt `dist/APRSPropView.exe` successfully, 39.8 MB

## Notes
- `dist/` and `build/` are ignored by the repository, so the rebuilt executable is local to the workspace and not included in this branch.
